### PR TITLE
feat: Add script to upload FHIR examples with dependency handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "render-pdf-previews": "bun scripts/render-pdf-previews.ts"
+    "render-pdf-previews": "bun scripts/render-pdf-previews.ts",
+    "upload-examples": "bun scripts/upload-examples.ts"
   },
   "dependencies": {
     "@napi-rs/canvas": "^0.1.54",

--- a/scripts/upload-examples.ts
+++ b/scripts/upload-examples.ts
@@ -1,0 +1,152 @@
+import { readdir, readFile } from 'fs/promises';
+import { join, resolve } from 'path';
+
+const fhirServerUrl = 'https://cdr.fhirlab.net/fhir';
+const resourcesDir = resolve(process.cwd(), 'fsh-generated', 'resources');
+const excludedResourceTypes = [
+  'StructureDefinition',
+  'Questionnaire',
+  'CodeSystem',
+  'ValueSet',
+  'SearchParameter',
+  'StructureMap',
+  'Library',
+  'ImplementationGuide', // Added this
+];
+
+// This order is important to resolve dependencies between resources
+const uploadOrder = [
+    'Location',
+    'Organization',
+    'Practitioner',
+    'Patient',
+    'HealthcareService',
+    'Coverage',
+    'Encounter',
+    'AllergyIntolerance',
+    'Condition',
+    'MedicationStatement',
+    'ServiceRequest',
+    'Procedure',
+    'Observation',
+    'DocumentReference',
+    'Task',
+    'Composition',
+    'Claim',
+    'Bundle',
+];
+
+
+async function uploadExamples() {
+  console.log(`Uploading examples to ${fhirServerUrl}`);
+  console.log(`Reading from ${resourcesDir}`);
+
+  try {
+    const files = await readdir(resourcesDir);
+    const resourcesByType = new Map<string, any[]>();
+
+    // Read and group all resources by type
+    for (const file of files) {
+      if (!file.endsWith('.json')) {
+        continue;
+      }
+
+      const filePath = join(resourcesDir, file);
+      const fileContent = await readFile(filePath, 'utf-8');
+      const resource = JSON.parse(fileContent);
+
+      if (excludedResourceTypes.includes(resource.resourceType)) {
+        continue;
+      }
+      
+      if (!resource.id) {
+        console.log(`Skipping resource with no id: ${file}`);
+        continue;
+      }
+
+      if (!resourcesByType.has(resource.resourceType)) {
+        resourcesByType.set(resource.resourceType, []);
+      }
+      resourcesByType.get(resource.resourceType)!.push(resource);
+    }
+
+    // Upload resources in the specified order
+    for (const resourceType of uploadOrder) {
+        const resourcesToUpload = resourcesByType.get(resourceType);
+        if (!resourcesToUpload || resourcesToUpload.length === 0) {
+            continue;
+        }
+
+        console.log(`Uploading ${resourcesToUpload.length} ${resourceType}(s)...`);
+
+        const uploadPromises = resourcesToUpload.map(resource => {
+            const url = `${fhirServerUrl}/${resource.resourceType}/${resource.id}`;
+            return fetch(url, {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/fhir+json',
+                },
+                body: JSON.stringify(resource),
+            }).then(response => {
+                if (!response.ok) {
+                    return response.text().then(responseBody => {
+                        console.error(`Failed to upload ${resource.resourceType}/${resource.id}: ${response.status} ${response.statusText}`, responseBody);
+                    });
+                } else {
+                    console.log(`Successfully uploaded ${resource.resourceType}/${resource.id}`);
+                }
+            }).catch(error => {
+                console.error(`Error uploading ${resource.resourceType}/${resource.id}:`, error);
+            });
+        });
+
+        await Promise.all(uploadPromises);
+        console.log(`Finished uploading ${resourceType}(s).`);
+        resourcesByType.delete(resourceType); // Remove uploaded resources from map
+    }
+
+    // Upload any remaining resource types that were not in the uploadOrder list
+    for (const [resourceType, resourcesToUpload] of resourcesByType.entries()) {
+        if (resourcesToUpload.length === 0) {
+            continue;
+        }
+        console.log(`Uploading ${resourcesToUpload.length} remaining ${resourceType}(s)...`);
+
+        const uploadPromises = resourcesToUpload.map(resource => {
+            const url = `${fhirServerUrl}/${resource.resourceType}/${resource.id}`;
+            return fetch(url, {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/fhir+json',
+                },
+                body: JSON.stringify(resource),
+            }).then(response => {
+                if (!response.ok) {
+                    return response.text().then(responseBody => {
+                        console.error(`Failed to upload ${resource.resourceType}/${resource.id}: ${response.status} ${response.statusText}`, responseBody);
+                    });
+                } else {
+                    console.log(`Successfully uploaded ${resource.resourceType}/${resource.id}`);
+                }
+            }).catch(error => {
+                console.error(`Error uploading ${resource.resourceType}/${resource.id}:`, error);
+            });
+        });
+
+        await Promise.all(uploadPromises);
+        console.log(`Finished uploading ${resourceType}(s).`);
+    }
+
+
+    console.log('Finished uploading all examples.');
+
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+        console.error('Error: The directory fsh-generated/resources does not exist. Please run the build script first.');
+    } else {
+        console.error('Error reading resources directory:', error);
+    }
+  }
+}
+
+uploadExamples();

--- a/scripts/uploadfig.ps1
+++ b/scripts/uploadfig.ps1
@@ -1,6 +1,6 @@
 UploadFIG `
 -d "https://tx.fhirlab.net/fhir" `
--s "https://build.fhir.org/ig/UPM-NTHC/PH-RoadSafetyIG/branches/35-add-examples-for-each-profile/package.r4.tgz" `
+-s "https://build.fhir.org/ig/UPM-NTHC/PH-RoadSafetyIG/package.r4.tgz" `
 -ip "example.fhir.ph.core|current" `
 -r StructureDefinition `
 -r Questionnaire `
@@ -8,6 +8,19 @@ UploadFIG `
 -r StructureMap `
 -r Library `
 --includeReferencedDependencies
+
+UploadFIG `
+-d "https://cdr.fhirlab.net/fhir" `
+-s "https://build.fhir.org/ig/UPM-NTHC/PH-RoadSafetyIG/package.r4.tgz" `
+-ip "example.fhir.ph.core|current" `
+-r StructureDefinition `
+-r Questionnaire `
+-r SearchParameter `
+-r StructureMap `
+-r Library `
+--includeExamples `
+--includeReferencedDependencies
+
 # -ets "https://tx.fhirlab.net/fhir"
 #  -reg "https://cdr.fhir.net/fhir/" `
  #  -r StructureDefinition `

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -9,7 +9,7 @@ name: PH-RoadSafetyIG
 title: DRAFT PH Road Safety Implementation Guide
 description: FHIR IG for road safety and health information in the Philippines
 status: draft # draft | active | retired | unknown
-version: 0.2.0
+version: 0.3.0
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
 copyrightYear: 2025+
 releaseLabel: ci-build


### PR DESCRIPTION
This PR introduces a new Bun script (scripts/upload-examples.ts) to facilitate the uploading of FHIR example resources to a FHIR server.
The script addresses the issue of referential integrity by uploading resources in a predefined order, ensuring that dependent resources (e.g., Patient, Encounter) are created before resources that reference them (e.g., Observation).

**Changes include:**
- New script scripts/upload-examples.ts for uploading examples.
- Updated package.json with a new upload-examples script command.
- Excluded ImplementationGuide from the upload process as it is a conformance resource.

This resolves issue #46.